### PR TITLE
update extproc dockerfile

### DIFF
--- a/Dockerfile.extproc
+++ b/Dockerfile.extproc
@@ -1,41 +1,55 @@
-# Build the Rust library for the candle-binding module
+# Build the Rust library using Makefile
 FROM rust:1.85 as rust-builder
 
+# Install make and other build dependencies
+RUN apt-get update && apt-get install -y \
+    make \
+    build-essential \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
+
+# Copy only essential files for Rust build
+COPY Makefile ./
 COPY candle-binding/Cargo.toml candle-binding/
 COPY candle-binding/src/ candle-binding/src/
 
-WORKDIR /app/candle-binding
-RUN cargo build --release
+# Use Makefile to build the Rust library
+RUN make rust
 
 # Build the Go application
 FROM golang:1.24 as go-builder
 
 WORKDIR /app
-COPY semantic_router/go.mod semantic_router/go.sum* ./
 
-# Create the directory for the candle-binding module
-RUN mkdir /app/candle-binding
-# Copy only the necessary Go files and go.mod for the candle-binding module
-COPY candle-binding/go.mod candle-binding/semantic_router.go /app/candle-binding/
+# Copy Go module files first for better layer caching
+COPY semantic_router/go.mod semantic_router/go.sum semantic_router/
+COPY candle-binding/go.mod candle-binding/semantic_router.go candle-binding/
 
-COPY semantic_router/ ./semantic_router/
+# Download Go dependencies
+RUN cd semantic_router && go mod download
 
-# Copy the .so file from the rust-builder for CGO
-COPY --from=rust-builder /app/candle-binding/target/release/libcandle_semantic_router.so /app/lib/
-# Set environment for CGO to find the library
-ENV CGO_LDFLAGS="-L/app/lib"
+# Copy semantic_router source code
+COPY semantic_router/ semantic_router/
+
+# Copy the built Rust library from rust-builder
+COPY --from=rust-builder /app/candle-binding/target/release/libcandle_semantic_router.so /app/candle-binding/target/release/
+
+# Set environment variables for CGO to find the library
 ENV CGO_ENABLED=1
+ENV LD_LIBRARY_PATH=/app/candle-binding/target/release
 
-RUN cd /app/semantic_router && go build -o extproc-server ./cmd/main.go
+# Build the router binary
+RUN mkdir -p bin && cd semantic_router && go build -o ../bin/router cmd/main.go
 
 # Final stage: copy the binary and the shared library
 FROM quay.io/centos/centos:stream9
 
 WORKDIR /app
 
-COPY --from=go-builder /app/semantic_router/extproc-server /app/
-COPY --from=go-builder /app/lib/libcandle_semantic_router.so /app/lib/
+COPY --from=go-builder /app/bin/router /app/extproc-server
+COPY --from=go-builder /app/candle-binding/target/release/libcandle_semantic_router.so /app/lib/
 COPY config/config.yaml /app/config/
 
 ENV LD_LIBRARY_PATH=/app/lib


### PR DESCRIPTION
This dockerfile just builds extproc. The model files need to bind mount:
```console
$ podman run -v `pwd`/models:/app/models router:extproc
2025/08/18 21:52:52 Starting metrics server on :9190
2025/08/18 21:52:52 Loaded category mapping with 14 categories
2025/08/18 21:52:52 Loaded PII mapping with 35 PII types
Initializing BERT similarity model: sentence-transformers/all-MiniLM-L12-v2
2025/08/18 21:52:52 Loaded jailbreak mapping with 2 jailbreak types
Loading model from HuggingFace Hub: sentence-transformers/all-MiniLM-L12-v2
Initializing ModernBERT classifier model: models/category_classifier_modernbert-base_model
Initializing ModernBERT PII token classifier model: models/pii_classifier_modernbert-base_presidio_token_model
2025/08/18 21:53:09 Initialized ModernBERT category classifier (classes auto-detected from model)
Initializing ModernBERT jailbreak classifier model: models/jailbreak_classifier_modernbert-base_model
2025/08/18 21:53:12 Initialized ModernBERT PII token classifier for entity detection
2025/08/18 21:53:16 Initialized ModernBERT jailbreak classifier (classes auto-detected from model)
2025/08/18 21:53:16 Category descriptions: [business law psychology biology chemistry history other health economics math physics computer science philosophy engineering]
2025/08/18 21:53:16 Semantic cache enabled with threshold: 0.8000, max entries: 1000, TTL: 3600 seconds
2025/08/18 21:53:16 Warning: Failed to load tools from file config/tools_db.json: failed to read tools file: open config/tools_db.json: no such file or directory
2025/08/18 21:53:16 Tools database enabled with threshold: 0.2000, top-k: 3
2025/08/18 21:53:16 Initialized ModernBERT jailbreak classifier (classes auto-detected from model)
2025/08/18 21:53:16 Starting LLM Semantic Router ExtProc with config: /app/config/config.yaml
2025/08/18 21:53:16 Starting LLM Router ExtProc server on port 50051...
```